### PR TITLE
Fix Capitalization Error in line 35 Include

### DIFF
--- a/src/OSVRDisplay.h
+++ b/src/OSVRDisplay.h
@@ -32,7 +32,7 @@
 // Library/third-party includes
 #include <openvr_driver.h>
 
-#include <osvr/display/Display.h>
+#include <osvr/Display/Display.h>
 #include <osvr/RenderKit/osvr_display_configuration.h>
 #include <osvr/Util/PlatformConfig.h>
 


### PR DESCRIPTION
On case-sensitive filesystems (like those used in Linux), compilation fails because `#include <osvr/display/Display.h>` is looking for a lowercase D, whereas the actual directory begins with an uppercase D.